### PR TITLE
[PHP-35]: Fix validation messages path and add test for it

### DIFF
--- a/src/Factories/ClientFactory.php
+++ b/src/Factories/ClientFactory.php
@@ -78,8 +78,9 @@ final class ClientFactory implements ClientFactoryInterface
     private function makeValidatorFactory(): void
     {
         $filesystem = new \Illuminate\Filesystem\Filesystem();
-        $loader = new \Illuminate\Translation\FileLoader($filesystem, \dirname(__FILE__, 4) . '/lang');
-        $loader->addNamespace('lang', \dirname(__FILE__, 4) . '/lang');
+        $langPath = \dirname(__FILE__, 3) . '/lang';
+        $loader = new \Illuminate\Translation\FileLoader($filesystem, $langPath);
+        $loader->addNamespace('lang', $langPath);
         $loader->load('en', 'validation', 'lang');
         $translationFactory = new \Illuminate\Translation\Translator($loader, 'en');
 

--- a/tests/integration/ValidationTest.php
+++ b/tests/integration/ValidationTest.php
@@ -9,7 +9,7 @@ use TrueLayer\Exceptions\ValidationException;
         \client()->payment()->create();
     } catch (ValidationException $e) {
         $errors = $e->getErrors();
-        expect($errors['amount_in_minor'][0])->toBe('The amount in minor field is required.');
+        \expect($errors['amount_in_minor'][0])->toBe('The amount in minor field is required.');
 
         throw $e;
     }

--- a/tests/integration/ValidationTest.php
+++ b/tests/integration/ValidationTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use TrueLayer\Exceptions\ValidationException;
+
+\it('has loaded validation message translations', function () {
+    try {
+        \client()->payment()->create();
+    } catch (ValidationException $e) {
+        $errors = $e->getErrors();
+        expect($errors['amount_in_minor'][0])->toBe('The amount in minor field is required.');
+
+        throw $e;
+    }
+})->throws(ValidationException::class);


### PR DESCRIPTION
When we throw `ValidationException` errors, the error messages are not translated because the translation path we provide to the Illuminate Translator is wrong.

This PR fixes that issue and adds a test to prevent further regressions.