### PR TITLE
PHP-52: Allow custom scopes, remove auto formatter, increase test waits 

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,7 @@ name: PHP
 
 on:
   push:
-    branches: [ main, feature/PHP-20 ]
+    branches: [ main ]
     tags:
       - "v**"
   pull_request:
@@ -11,39 +11,6 @@ on:
     - cron: '0 9,14,17 * * *'
 
 jobs:
-  code-style:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          coverage: none
-          php-version: "8.0"
-          ini-values: memory_limit=-1
-        env:
-          update: true
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.composer/cache
-            vendor
-          key: php-cs-fixer
-
-      - name: Install
-        run: composer install
-
-      - name: Run php-cs-fixer
-        run: composer cs-fix
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Apply php-cs-fixer changes
-
   code-quality:
     runs-on: ubuntu-latest
     strategy:
@@ -90,7 +57,7 @@ jobs:
 
       - name: Integration Tests
         run: composer integration-tests
-        
+
       - name: Acceptance Tests
         run: |
           touch .env

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ $client = \TrueLayer\Client::configure()
     ->create(); 
 ```
 
+This library assumes that your client_id is issued with the `payments` scope. Depending on your account type this may
+not be the case and the authentication server will return an `invalid_scope` error. You can override the scopes used by
+the library with the `scopes()` method:
+
+```php
+$client = \TrueLayer\Client::configure()
+    ...
+    ->scopes('foo', 'bar')
+    ->create(); 
+```
+
 <a name="caching"></a>
 
 ## Caching

--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,15 @@
         "integration-tests": "vendor/bin/pest --test-directory tests/integration",
         "acceptance-tests": "vendor/bin/pest --test-directory tests/acceptance",
         "cs-fix": "vendor/bin/php-cs-fixer fix",
-        "checks": "@composer analyse && composer cs-fix && composer integration-tests && composer acceptance-tests"
+        "checks": [
+            "@analyse",
+            "@cs-fix",
+            "@integration-tests",
+            "@acceptance-tests"
+        ]
     },
     "config": {
+        "process-timeout": 0,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/src/Constants/Scopes.php
+++ b/src/Constants/Scopes.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrueLayer\Constants;
+
+class Scopes
+{
+    public const DEFAULT = 'payments';
+}

--- a/src/Factories/ClientFactory.php
+++ b/src/Factories/ClientFactory.php
@@ -102,7 +102,7 @@ final class ClientFactory implements ClientFactoryInterface
             $this->validatorFactory,
             $config->getClientId(),
             $config->getClientSecret(),
-            ['payments', 'paydirect'],
+            $config->getScopes(),
         );
     }
 

--- a/src/Interfaces/Configuration/ClientConfigInterface.php
+++ b/src/Interfaces/Configuration/ClientConfigInterface.php
@@ -88,6 +88,18 @@ interface ClientConfigInterface extends ConfigInterface
     public function getPassphrase(): ?string;
 
     /**
+     * @param string ...$scopes
+     *
+     * @return $this
+     */
+    public function scopes(string ...$scopes): self;
+
+    /**
+     * @return string[]
+     */
+    public function getScopes(): array;
+
+    /**
      * @throws SignerException
      *
      * @return ClientInterface

--- a/src/Services/ApiClient/ApiClient.php
+++ b/src/Services/ApiClient/ApiClient.php
@@ -47,9 +47,9 @@ final class ApiClient implements ApiClientInterface
     /**
      * @param ApiRequestInterface $apiRequest
      *
-     * @throws ApiRequestJsonSerializationException
      * @throws ApiResponseUnsuccessfulException
      * @throws ClientExceptionInterface
+     * @throws ApiRequestJsonSerializationException
      *
      * @return mixed
      */

--- a/src/Services/Client/ClientConfig.php
+++ b/src/Services/Client/ClientConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Services\Client;
 
+use TrueLayer\Constants\Scopes;
 use TrueLayer\Exceptions\SignerException;
 use TrueLayer\Interfaces\Client\ClientFactoryInterface;
 use TrueLayer\Interfaces\Client\ClientInterface;
@@ -41,6 +42,11 @@ class ClientConfig extends Config implements ClientConfigInterface
      * @var string|null
      */
     private ?string $passphrase = null;
+
+    /**
+     * @var string[]
+     */
+    private array $scopes = [Scopes::DEFAULT];
 
     /**
      * @param ClientFactoryInterface $factory
@@ -184,6 +190,26 @@ class ClientConfig extends Config implements ClientConfigInterface
     public function getPassphrase(): ?string
     {
         return $this->passphrase;
+    }
+
+    /**
+     * @param string ...$scopes
+     *
+     * @return $this
+     */
+    public function scopes(string ...$scopes): self
+    {
+        $this->scopes = $scopes;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
     }
 
     /**

--- a/tests/acceptance/Payment/MerchantAccountPaymentAuthorizationTest.php
+++ b/tests/acceptance/Payment/MerchantAccountPaymentAuthorizationTest.php
@@ -92,7 +92,7 @@ use TrueLayer\Interfaces\Provider\ProviderInterface;
     $next = $created->getDetails()->getAuthorizationFlowNextAction();
 
     \bankAction($next->getUri(), 'Execute');
-    \sleep(15);
+    \sleep(120);
 
     /* @var PaymentSettledInterface $payment */
     $payment = $created->getDetails();

--- a/tests/acceptance/PayoutTest.php
+++ b/tests/acceptance/PayoutTest.php
@@ -31,7 +31,7 @@ use TrueLayer\Interfaces\Payout\PayoutRetrievedInterface;
     /** @var RedirectActionInterface $next */
     $next = $created->getDetails()->getAuthorizationFlowNextAction();
     \bankAction($next->getUri(), 'Execute');
-    \sleep(15);
+    \sleep(120);
 
     /* @var PaymentSettledInterface $payment */
     $payment = $created->getDetails();

--- a/tests/acceptance/RefundTest.php
+++ b/tests/acceptance/RefundTest.php
@@ -42,7 +42,7 @@ function assertRefundCommon(RefundRetrievedInterface $refund)
         $next = $created->getDetails()->getAuthorizationFlowNextAction();
 
         \bankAction($next->getUri(), 'Execute');
-        \sleep(10);
+        \sleep(120);
 
         $response = $client->refund()
             ->payment($created)

--- a/tests/integration/ApiClient/AccessTokenTest.php
+++ b/tests/integration/ApiClient/AccessTokenTest.php
@@ -130,3 +130,22 @@ use TrueLayer\Tests\Integration\Mocks;
     \expect($fooRequest->getHeaderLine('Authorization'))->toBe('Bearer ' . Mocks\AuthResponse::ACCESS_TOKEN);
     \expect($fooRequest->getHeaderLine('Authorization'))->not()->toBe('Bearer expired-token');
 });
+
+\it('uses default scope if none provided', function () {
+    $client = \rawClient([Mocks\AuthResponse::success(), new Response(200)])->create();
+    $client->getApiClient()->request()->uri('/test')->post();
+
+    $requestedScope = \getRequestPayload(0)['scope'];
+    \expect($requestedScope)->toBe(\TrueLayer\Constants\Scopes::DEFAULT);
+});
+
+\it('uses custom scopes if provided', function () {
+    $client = \rawClient([Mocks\AuthResponse::success(), new Response(200)])
+        ->scopes('foo', 'bar')
+        ->create();
+
+    $client->getApiClient()->request()->uri('/test')->post();
+
+    $requestedScope = \getRequestPayload(0)['scope'];
+    \expect($requestedScope)->toBe('foo bar');
+});


### PR DESCRIPTION
We will now allow setting custom scopes on the client lib config. This is necessary as we will start issuing different scopes to different types of accounts. 