### PR TITLE
[PHP-70] Support for setting the user's address and date of birth

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,8 +23,6 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
-          - "8.2"
-          - "8.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,6 +23,8 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2024-02-09
+
+### Added
+
+- Support for setting the user's address using `$client->user()->address()`
+- Support for setting the user's date of birth using `$client->user()->dateOfBirth()`
+
 ## [1.5.0] - 2024-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -207,7 +207,21 @@ $beneficiary = $client->beneficiary()->externalAccount()
 $user = $client->user()
     ->name('Jane Doe')
     ->phone('+44123456789')
-    ->email('jane.doe@truelayer.com');
+    ->email('jane.doe@truelayer.com')
+    ->dateOfBirth('2024-01-01');
+```
+
+You are also able to set the user's address:
+
+```php
+$address = $client->user()
+    ->address()
+    ->addressLine1('The Gilbert')
+    ->addressLine2('City of')
+    ->city('London')
+    ->state('London')
+    ->zip('EC2A 1PX')
+    ->countryCode('GB');
 ```
 
 <a name="creating-a-payment-method"></a>

--- a/config/bindings.php
+++ b/config/bindings.php
@@ -3,12 +3,13 @@
 declare(strict_types=1);
 
 use TrueLayer\Entities;
-use TrueLayer\Entities\User;
 use TrueLayer\Interfaces;
 
 return [
-    Interfaces\UserInterface::class => User::class,
     Interfaces\HppInterface::class => 'makeHpp',
+
+    Interfaces\AddressInterface::class => Entities\Address::class,
+    Interfaces\UserInterface::class => Entities\User::class,
 
     Interfaces\Beneficiary\BeneficiaryBuilderInterface::class => Entities\Beneficiary\BeneficiaryBuilder::class,
     Interfaces\Beneficiary\MerchantBeneficiaryInterface::class => Entities\Beneficiary\MerchantBeneficiary::class,

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TrueLayer\Entities;
 
 use TrueLayer\Interfaces\AddressInterface;

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -63,11 +63,11 @@ class Address extends Entity implements AddressInterface
     ];
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getAddressLine1(): string
+    public function getAddressLine1(): ?string
     {
-        return $this->addressLine1;
+        return $this->addressLine1 ?? null;
     }
 
     /**
@@ -103,11 +103,11 @@ class Address extends Entity implements AddressInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCity(): string
+    public function getCity(): ?string
     {
-        return $this->city;
+        return $this->city ?? null;
     }
 
     /**
@@ -123,11 +123,11 @@ class Address extends Entity implements AddressInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getState(): string
+    public function getState(): ?string
     {
-        return $this->state;
+        return $this->state ?? null;
     }
 
     /**
@@ -143,11 +143,11 @@ class Address extends Entity implements AddressInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getZip(): string
+    public function getZip(): ?string
     {
-        return $this->zip;
+        return $this->zip ?? null;
     }
 
     /**
@@ -163,11 +163,11 @@ class Address extends Entity implements AddressInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCountryCode(): string
+    public function getCountryCode(): ?string
     {
-        return $this->countryCode;
+        return $this->countryCode ?? null;
     }
 
     /**

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -57,7 +57,7 @@ class Address extends Entity implements AddressInterface
         'address_line1' => 'string|required',
         'address_line2' => 'string|nullable',
         'city' => 'string|required',
-        'state' => 'string|required',
+        'state' => 'string|nullable',
         'zip' => 'string|required',
         'country_code' => 'string|required',
     ];

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace TrueLayer\Entities;
+
+use TrueLayer\Interfaces\AddressInterface;
+
+class Address extends Entity implements AddressInterface
+{
+    /**
+     * @var string
+     */
+    protected string $addressLine1;
+
+    /**
+     * @var string
+     */
+    protected string $addressLine2;
+
+    /**
+     * @var string
+     */
+    protected string $city;
+
+    /**
+     * @var string
+     */
+    protected string $state;
+
+    /**
+     * @var string
+     */
+    protected string $zip;
+
+    /**
+     * @var string
+     */
+    protected string $countryCode;
+
+    /**
+     * @var string[]
+     */
+    protected array $arrayFields = [
+        'address_line1',
+        'address_line2',
+        'city',
+        'state',
+        'zip',
+        'country_code',
+    ];
+
+    /**
+     * @return array
+     */
+    protected function rules(): array
+    {
+        return [
+            'address_line1' => 'string|required',
+            'address_line2' => 'string|nullable',
+            'city' => 'string|required',
+            'state' => 'string|required',
+            'zip' => 'string|required',
+            'country_code' => 'string|required',
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getAddressLine1(): string
+    {
+        return $this->addressLine1;
+    }
+
+    /**
+     * @param string $addressLine1
+     *
+     * @return AddressInterface
+     */
+    public function addressLine1(string $addressLine1): AddressInterface
+    {
+        $this->addressLine1 = $addressLine1;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddressLine2(): ?string
+    {
+        return $this->addressLine2 ?? null;
+    }
+
+    /**
+     * @param string $addressLine2
+     *
+     * @return AddressInterface
+     */
+    public function addressLine2(string $addressLine2): AddressInterface
+    {
+        $this->addressLine2 = $addressLine2;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCity(): string
+    {
+        return $this->city;
+    }
+
+    /**
+     * @param string $city
+     *
+     * @return AddressInterface
+     */
+    public function city(string $city): AddressInterface
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getState(): string
+    {
+        return $this->state;
+    }
+
+    /**
+     * @param string $state
+     *
+     * @return AddressInterface
+     */
+    public function state(string $state): AddressInterface
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getZip(): string
+    {
+        return $this->zip;
+    }
+
+    /**
+     * @param string $zip
+     *
+     * @return AddressInterface
+     */
+    public function zip(string $zip): AddressInterface
+    {
+        $this->zip = $zip;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    /**
+     * @param string $countryCode
+     *
+     * @return AddressInterface
+     */
+    public function countryCode(string $countryCode): AddressInterface
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+}

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -51,19 +51,16 @@ class Address extends Entity implements AddressInterface
     ];
 
     /**
-     * @return array
+     * @var string[]
      */
-    protected function rules(): array
-    {
-        return [
-            'address_line1' => 'string|required',
-            'address_line2' => 'string|nullable',
-            'city' => 'string|required',
-            'state' => 'string|required',
-            'zip' => 'string|required',
-            'country_code' => 'string|required',
-        ];
-    }
+    protected array $rules = [
+        'address_line1' => 'string|required',
+        'address_line2' => 'string|nullable',
+        'city' => 'string|required',
+        'state' => 'string|required',
+        'zip' => 'string|required',
+        'country_code' => 'string|required',
+    ];
 
     /**
      * @return string

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -23,7 +23,7 @@ abstract class Entity implements ArrayableInterface, HasAttributesInterface
     /**
      * @var EntityFactoryInterface
      */
-    private EntityFactoryInterface $entityFactory;
+    protected EntityFactoryInterface $entityFactory;
 
     /**
      * @param ValidatorFactory       $validatorFactory

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -178,6 +178,7 @@ final class User extends Entity implements UserInterface
 
         return $this->address;
     }
+
     /**
      * @return string|null
      */

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities;
 
+use TrueLayer\Exceptions\InvalidArgumentException;
+use TrueLayer\Exceptions\ValidationException;
+use TrueLayer\Interfaces\AddressInterface;
 use TrueLayer\Interfaces\UserInterface;
+use TrueLayer\Validation\ValidType;
 
 final class User extends Entity implements UserInterface
 {
@@ -29,6 +33,16 @@ final class User extends Entity implements UserInterface
     protected string $phone;
 
     /**
+     * @var AddressInterface
+     */
+    protected AddressInterface $address;
+
+    /**
+     * @var string
+     */
+    protected string $dateOfBirth;
+
+    /**
      * @var string[]
      */
     protected array $arrayFields = [
@@ -36,17 +50,31 @@ final class User extends Entity implements UserInterface
         'name',
         'email',
         'phone',
+        'address',
+        'date_of_birth',
     ];
 
     /**
      * @var string[]
      */
-    protected array $rules = [
-        'id' => 'string|nullable',
-        'name' => 'string|nullable|required_without:id',
-        'email' => 'string|nullable|email|required_without_all:phone,id',
-        'phone' => 'string|nullable|required_without_all:email,id',
+    protected array $casts = [
+        'address' => AddressInterface::class,
     ];
+
+    /**
+     * @return array
+     */
+    protected function rules(): array
+    {
+        return [
+            'id' => 'string|nullable',
+            'name' => 'string|nullable|required_without:id',
+            'email' => 'string|nullable|email|required_without_all:phone,id',
+            'phone' => 'string|nullable|required_without_all:email,id',
+            'address' => ['nullable', ValidType::of(AddressInterface::class)],
+            'date_of_birth' => 'string|nullable|date',
+        ];
+    }
 
     /**
      * @return string|null
@@ -124,6 +152,57 @@ final class User extends Entity implements UserInterface
     public function phone(string $phone): UserInterface
     {
         $this->phone = $phone;
+
+        return $this;
+    }
+
+    /**
+     * @return AddressInterface|null
+     */
+    public function getAddress(): ?AddressInterface
+    {
+        return $this->address ?? null;
+    }
+
+    /**
+     * @param AddressInterface $address
+     *
+     * @return UserInterface
+     */
+    public function address(AddressInterface $address): UserInterface
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    /**
+     * @throws ValidationException
+     * @throws InvalidArgumentException
+     *
+     * @return AddressInterface
+     */
+    public function addressBuilder(): AddressInterface
+    {
+        return $this->entityFactory->make(AddressInterface::class);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDateOfBirth(): ?string
+    {
+        return $this->dateOfBirth ?? null;
+    }
+
+    /**
+     * @param string $dateOfBirth
+     *
+     * @return UserInterface
+     */
+    public function dateOfBirth(string $dateOfBirth): UserInterface
+    {
+        $this->dateOfBirth = $dateOfBirth;
 
         return $this;
     }

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -62,7 +62,7 @@ final class User extends Entity implements UserInterface
     ];
 
     /**
-     * @return array
+     * @return mixed[]
      */
     protected function rules(): array
     {
@@ -176,7 +176,7 @@ final class User extends Entity implements UserInterface
     {
         $this->address = $address ?: $this->entityFactory->make(AddressInterface::class);
 
-        return $this->getAddress();
+        return $this->address;
     }
     /**
      * @return string|null

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -165,28 +165,19 @@ final class User extends Entity implements UserInterface
     }
 
     /**
-     * @param AddressInterface $address
+     * @param AddressInterface|null $address
      *
-     * @return UserInterface
-     */
-    public function address(AddressInterface $address): UserInterface
-    {
-        $this->address = $address;
-
-        return $this;
-    }
-
-    /**
      * @throws ValidationException
      * @throws InvalidArgumentException
      *
      * @return AddressInterface
      */
-    public function addressBuilder(): AddressInterface
+    public function address(?AddressInterface $address = null): AddressInterface
     {
-        return $this->entityFactory->make(AddressInterface::class);
-    }
+        $this->address = $address ?: $this->entityFactory->make(AddressInterface::class);
 
+        return $this->getAddress();
+    }
     /**
      * @return string|null
      */

--- a/src/Interfaces/AddressInterface.php
+++ b/src/Interfaces/AddressInterface.php
@@ -7,9 +7,9 @@ namespace TrueLayer\Interfaces;
 interface AddressInterface extends ArrayableInterface, HasAttributesInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
-    public function getAddressLine1(): string;
+    public function getAddressLine1(): ?string;
 
     /**
      * @param string $addressLine1
@@ -31,9 +31,9 @@ interface AddressInterface extends ArrayableInterface, HasAttributesInterface
     public function addressLine2(string $addressLine2): AddressInterface;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCity(): string;
+    public function getCity(): ?string;
 
     /**
      * @param string $city
@@ -43,9 +43,9 @@ interface AddressInterface extends ArrayableInterface, HasAttributesInterface
     public function city(string $city): AddressInterface;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getState(): string;
+    public function getState(): ?string;
 
     /**
      * @param string $state
@@ -55,9 +55,9 @@ interface AddressInterface extends ArrayableInterface, HasAttributesInterface
     public function state(string $state): AddressInterface;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getZip(): string;
+    public function getZip(): ?string;
 
     /**
      * @param string $zip
@@ -67,9 +67,9 @@ interface AddressInterface extends ArrayableInterface, HasAttributesInterface
     public function zip(string $zip): AddressInterface;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCountryCode(): string;
+    public function getCountryCode(): ?string;
 
     /**
      * @param string $countryCode

--- a/src/Interfaces/AddressInterface.php
+++ b/src/Interfaces/AddressInterface.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrueLayer\Interfaces;
+
+interface AddressInterface extends ArrayableInterface, HasAttributesInterface
+{
+    /**
+     * @return string
+     */
+    public function getAddressLine1(): string;
+
+    /**
+     * @param string $addressLine1
+     *
+     * @return AddressInterface
+     */
+    public function addressLine1(string $addressLine1): AddressInterface;
+
+    /**
+     * @return string|null
+     */
+    public function getAddressLine2(): ?string;
+
+    /**
+     * @param string $addressLine2
+     *
+     * @return AddressInterface
+     */
+    public function addressLine2(string $addressLine2): AddressInterface;
+
+    /**
+     * @return string
+     */
+    public function getCity(): string;
+
+    /**
+     * @param string $city
+     *
+     * @return AddressInterface
+     */
+    public function city(string $city): AddressInterface;
+
+    /**
+     * @return string
+     */
+    public function getState(): string;
+
+    /**
+     * @param string $state
+     *
+     * @return AddressInterface
+     */
+    public function state(string $state): AddressInterface;
+
+    /**
+     * @return string
+     */
+    public function getZip(): string;
+
+    /**
+     * @param string $zip
+     *
+     * @return AddressInterface
+     */
+    public function zip(string $zip): AddressInterface;
+
+    /**
+     * @return string
+     */
+    public function getCountryCode(): string;
+
+    /**
+     * @param string $countryCode
+     *
+     * @return AddressInterface
+     */
+    public function countryCode(string $countryCode): AddressInterface;
+}

--- a/src/Interfaces/UserInterface.php
+++ b/src/Interfaces/UserInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace TrueLayer\Interfaces;
 
+use TrueLayer\Exceptions\InvalidArgumentException;
+use TrueLayer\Exceptions\ValidationException;
+
 interface UserInterface extends ArrayableInterface, HasAttributesInterface
 {
     /**
@@ -53,4 +56,36 @@ interface UserInterface extends ArrayableInterface, HasAttributesInterface
      * @return UserInterface
      */
     public function phone(string $phone): UserInterface;
+
+    /**
+     * @return AddressInterface|null
+     */
+    public function getAddress(): ?AddressInterface;
+
+    /**
+     * @param AddressInterface $address
+     *
+     * @return UserInterface
+     */
+    public function address(AddressInterface $address): UserInterface;
+
+    /**
+     * @throws ValidationException
+     * @throws InvalidArgumentException
+     *
+     * @return AddressInterface
+     */
+    public function addressBuilder(): AddressInterface;
+
+    /**
+     * @return string|null
+     */
+    public function getDateOfBirth(): ?string;
+
+    /**
+     * @param string $dateOfBirth
+     *
+     * @return UserInterface
+     */
+    public function dateOfBirth(string $dateOfBirth): UserInterface;
 }

--- a/src/Interfaces/UserInterface.php
+++ b/src/Interfaces/UserInterface.php
@@ -63,19 +63,11 @@ interface UserInterface extends ArrayableInterface, HasAttributesInterface
     public function getAddress(): ?AddressInterface;
 
     /**
-     * @param AddressInterface $address
-     *
-     * @return UserInterface
-     */
-    public function address(AddressInterface $address): UserInterface;
-
-    /**
-     * @throws ValidationException
-     * @throws InvalidArgumentException
+     * @param AddressInterface|null $address
      *
      * @return AddressInterface
      */
-    public function addressBuilder(): AddressInterface;
+    public function address(?AddressInterface $address): AddressInterface;
 
     /**
      * @return string|null

--- a/src/Interfaces/UserInterface.php
+++ b/src/Interfaces/UserInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace TrueLayer\Interfaces;
 
-use TrueLayer\Exceptions\InvalidArgumentException;
-use TrueLayer\Exceptions\ValidationException;
-
 interface UserInterface extends ArrayableInterface, HasAttributesInterface
 {
     /**

--- a/tests/acceptance/Payment/CreatePayment.php
+++ b/tests/acceptance/Payment/CreatePayment.php
@@ -69,6 +69,26 @@ class CreatePayment
             ->email('alice@truelayer.com');
     }
 
+    public function userWithAddress(): UserInterface
+    {
+        $user = $this->user();
+        $address = $user->addressBuilder()
+            ->addressLine1("The Gilbert")
+            ->city("London")
+            ->state("London")
+            ->zip("EC2A 1PX")
+            ->countryCode("GB");
+
+        return $this->user()
+            ->address($address);
+    }
+
+    public function userWithDateOfBirth(string $date): UserInterface
+    {
+        return $this->user()
+            ->dateOfBirth($date);
+    }
+
     /**
      * @param BeneficiaryInterface $beneficiary
      *

--- a/tests/acceptance/Payment/CreatePayment.php
+++ b/tests/acceptance/Payment/CreatePayment.php
@@ -72,15 +72,14 @@ class CreatePayment
     public function userWithAddress(): UserInterface
     {
         $user = $this->user();
-        $address = $user->addressBuilder()
-            ->addressLine1("The Gilbert")
-            ->city("London")
-            ->state("London")
-            ->zip("EC2A 1PX")
-            ->countryCode("GB");
+        $user->address()
+            ->addressLine1('The Gilbert')
+            ->city('London')
+            ->state('London')
+            ->zip('EC2A 1PX')
+            ->countryCode('GB');
 
-        return $this->user()
-            ->address($address);
+        return $user;
     }
 
     public function userWithDateOfBirth(string $date): UserInterface

--- a/tests/acceptance/Payment/ExternalAccountPaymentAuthorizationTest.php
+++ b/tests/acceptance/Payment/ExternalAccountPaymentAuthorizationTest.php
@@ -66,7 +66,7 @@ use TrueLayer\Interfaces\Provider\ProviderInterface;
     \expect($config['redirect']['return_uri'])->toBe('https://console.truelayer.com/redirect-page');
 
     return $created;
-})->only();
+});
 
 \it('starts payment authorization', function () {
     $created = \paymentHelper()->create();
@@ -90,7 +90,7 @@ use TrueLayer\Interfaces\Provider\ProviderInterface;
     \expect($config['form']['input_types'])->toBeEmpty();
 
     return $created;
-})->only();
+});
 
 \it('starts payment authorization with hpp capabilities', function () {
     $created = \paymentHelper()->create();
@@ -108,7 +108,7 @@ use TrueLayer\Interfaces\Provider\ProviderInterface;
     \expect($config['redirect']['return_uri'])->toBe('https://console.truelayer.com/redirect-page');
     \expect($config['redirect'])->not->toHaveKey('direct_return_uri');
     \expect($config['form']['input_types'])->toContain(FormInputTypes::SELECT, FormInputTypes::TEXT, FormInputTypes::TEXT_WITH_IMAGE);
-})->only();
+});
 
 \it('starts payment authorization with all capabilities', function () {
     $created = \paymentHelper()->create();
@@ -130,7 +130,7 @@ use TrueLayer\Interfaces\Provider\ProviderInterface;
     \expect($config['redirect']['return_uri'])->toBe('https://console.truelayer.com/redirect-page');
     \expect($config['redirect']['direct_return_uri'])->toBe('https://console.truelayer.com/direct-return-page');
     \expect($config['form']['input_types'])->toContain(FormInputTypes::TEXT);
-})->only();
+});
 
 \it('retrieves payment as authorizing - provider selection', function (PaymentCreatedInterface $created) {
     /** @var PaymentAuthorizingInterface $payment */

--- a/tests/acceptance/Payment/MerchantAccountPaymentAuthorizationTest.php
+++ b/tests/acceptance/Payment/MerchantAccountPaymentAuthorizationTest.php
@@ -134,6 +134,53 @@ use TrueLayer\Interfaces\Provider\ProviderInterface;
     \expect($fetched->getId())->toBeString();
 });
 
+\it('creates payment with user address', function () {
+    $helper = \paymentHelper();
+
+    $payment = $helper->client()->payment()
+        ->paymentMethod($helper->bankTransferMethod($helper->sortCodeBeneficiary()))
+        ->amountInMinor(10)
+        ->currency('GBP')
+        ->user($helper->userWithAddress())
+        ->create();
+
+    $fetched = $payment->getDetails();
+
+    \expect($payment)->toBeInstanceOf(PaymentCreatedInterface::class);
+    \expect($payment->getId())->toBeString();
+    \expect($fetched)->toBeInstanceOf(PaymentRetrievedInterface::class);
+    \expect($fetched->getId())->toBeString();
+});
+
+\it('creates payment with valid user date of birth', function () {
+    $helper = \paymentHelper();
+
+    $payment = $helper->client()->payment()
+        ->paymentMethod($helper->bankTransferMethod($helper->sortCodeBeneficiary()))
+        ->amountInMinor(10)
+        ->currency('GBP')
+        ->user($helper->userWithDateOfBirth('2024-01-01'))
+        ->create();
+
+    $fetched = $payment->getDetails();
+
+    \expect($payment)->toBeInstanceOf(PaymentCreatedInterface::class);
+    \expect($payment->getId())->toBeString();
+    \expect($fetched)->toBeInstanceOf(PaymentRetrievedInterface::class);
+    \expect($fetched->getId())->toBeString();
+});
+
+\it('throws exception when creating payment with invalid user date of birth', function () {
+    $helper = \paymentHelper();
+
+    $helper->client()->payment()
+        ->paymentMethod($helper->bankTransferMethod($helper->sortCodeBeneficiary()))
+        ->amountInMinor(10)
+        ->currency('GBP')
+        ->user($helper->userWithDateOfBirth('invalid date'))
+        ->create();
+})->throws(TrueLayer\Exceptions\ValidationException::class);
+
 \it('creates payment with idempotency key', function () {
     $helper = \paymentHelper();
 

--- a/tests/integration/Mocks/CreatePayment.php
+++ b/tests/integration/Mocks/CreatePayment.php
@@ -59,20 +59,19 @@ class CreatePayment
 
     public function newUserWithAddress(): UserInterface
     {
-        $address = $this->client
-            ->user()
-            ->addressBuilder()
+        $user = $this->newUser();
+
+        $user->address()
             ->addressLine1("The Gilbert")
             ->city("London")
             ->state("London")
             ->zip("EC2A 1PX")
             ->countryCode("GB");
 
-        return $this->newUser()
-            ->address($address);
+        return $user;
     }
 
-    public function newUserWithDateOfBirth(string $date)
+    public function newUserWithDateOfBirth(string $date): UserInterface
     {
         return $this->newUser()
             ->dateOfBirth($date);

--- a/tests/integration/Mocks/CreatePayment.php
+++ b/tests/integration/Mocks/CreatePayment.php
@@ -57,15 +57,22 @@ class CreatePayment
             ->email('alice@truelayer.com');
     }
 
-    public function newUserWithAddress(): UserInterface
+    public function newUserWithAddress($a): UserInterface
     {
         $user = $this->newUser();
-        $user->address()
-            ->addressLine1('The Gilbert')
-            ->city('London')
-            ->state('London')
-            ->zip('EC2A 1PX')
-            ->countryCode('GB');
+        $address = $user->address()
+            ->addressLine1($a['addressLine1'])
+            ->city($a['city'])
+            ->zip($a['zip'])
+            ->countryCode($a['countryCode']);
+
+        if (array_key_exists('addressLine2', $a)) {
+            $address->addressLine2($a['addressLine2']);
+        }
+
+        if (array_key_exists('state', $a)) {
+           $address->state($a['state']);
+        }
 
         return $user;
     }

--- a/tests/integration/Mocks/CreatePayment.php
+++ b/tests/integration/Mocks/CreatePayment.php
@@ -62,11 +62,11 @@ class CreatePayment
         $user = $this->newUser();
 
         $user->address()
-            ->addressLine1("The Gilbert")
-            ->city("London")
-            ->state("London")
-            ->zip("EC2A 1PX")
-            ->countryCode("GB");
+            ->addressLine1('The Gilbert')
+            ->city('London')
+            ->state('London')
+            ->zip('EC2A 1PX')
+            ->countryCode('GB');
 
         return $user;
     }

--- a/tests/integration/Mocks/CreatePayment.php
+++ b/tests/integration/Mocks/CreatePayment.php
@@ -60,7 +60,6 @@ class CreatePayment
     public function newUserWithAddress(): UserInterface
     {
         $user = $this->newUser();
-
         $user->address()
             ->addressLine1('The Gilbert')
             ->city('London')

--- a/tests/integration/Mocks/CreatePayment.php
+++ b/tests/integration/Mocks/CreatePayment.php
@@ -66,12 +66,12 @@ class CreatePayment
             ->zip($a['zip'])
             ->countryCode($a['countryCode']);
 
-        if (array_key_exists('addressLine2', $a)) {
+        if (\array_key_exists('addressLine2', $a)) {
             $address->addressLine2($a['addressLine2']);
         }
 
-        if (array_key_exists('state', $a)) {
-           $address->state($a['state']);
+        if (\array_key_exists('state', $a)) {
+            $address->state($a['state']);
         }
 
         return $user;

--- a/tests/integration/Mocks/CreatePayment.php
+++ b/tests/integration/Mocks/CreatePayment.php
@@ -57,6 +57,27 @@ class CreatePayment
             ->email('alice@truelayer.com');
     }
 
+    public function newUserWithAddress(): UserInterface
+    {
+        $address = $this->client
+            ->user()
+            ->addressBuilder()
+            ->addressLine1("The Gilbert")
+            ->city("London")
+            ->state("London")
+            ->zip("EC2A 1PX")
+            ->countryCode("GB");
+
+        return $this->newUser()
+            ->address($address);
+    }
+
+    public function newUserWithDateOfBirth(string $date)
+    {
+        return $this->newUser()
+            ->dateOfBirth($date);
+    }
+
     /**
      * @return UserInterface
      */

--- a/tests/integration/PaymentCreateTest.php
+++ b/tests/integration/PaymentCreateTest.php
@@ -88,7 +88,80 @@ use TrueLayer\Tests\Integration\Mocks\PaymentResponse;
     $factory = CreatePayment::responses([
         PaymentResponse::created(),
     ]);
-    $factory->payment($factory->newUserWithAddress(), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
+
+    $address = [
+        'addressLine1' => 'The Gilbert',
+        'addressLine2' => 'City of',
+        'city' => 'London',
+        'state' => 'Greater London',
+        'zip' => 'EC2A 1PX',
+        'countryCode' => 'GB',
+    ];
+    $factory->payment($factory->newUserWithAddress($address), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
+
+    \expect(\getRequestPayload(1))->toMatchArray([
+        'user' => [
+            'id' => null,
+            'name' => 'Alice',
+            'phone' => '+447837485713',
+            'email' => 'alice@truelayer.com',
+            'address' => [
+                'address_line1' => 'The Gilbert',
+                'address_line2' => 'City of',
+                'city' => 'London',
+                'state' => 'Greater London',
+                'zip' => 'EC2A 1PX',
+                'country_code' => 'GB',
+            ],
+            'date_of_birth' => null,
+        ],
+    ]);
+});
+
+\it('ensures user address state is optional', function () {
+    $factory = CreatePayment::responses([
+        PaymentResponse::created(),
+    ]);
+    $address = [
+        'addressLine1' => 'The Gilbert',
+        'addressLine2' => 'City of',
+        'city' => 'London',
+        'zip' => 'EC2A 1PX',
+        'countryCode' => 'GB',
+    ];
+    $factory->payment($factory->newUserWithAddress($address), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
+
+    \expect(\getRequestPayload(1))->toMatchArray([
+        'user' => [
+            'id' => null,
+            'name' => 'Alice',
+            'phone' => '+447837485713',
+            'email' => 'alice@truelayer.com',
+            'address' => [
+                'address_line1' => 'The Gilbert',
+                'address_line2' => 'City of',
+                'city' => 'London',
+                'state' => null,
+                'zip' => 'EC2A 1PX',
+                'country_code' => 'GB',
+            ],
+            'date_of_birth' => null,
+        ],
+    ]);
+});
+
+\it('ensures user address addressLine2 is optional', function () {
+    $factory = CreatePayment::responses([
+        PaymentResponse::created(),
+    ]);
+    $address = [
+        'addressLine1' => 'The Gilbert',
+        'city' => 'London',
+        'state' => 'Greater London',
+        'zip' => 'EC2A 1PX',
+        'countryCode' => 'GB',
+    ];
+    $factory->payment($factory->newUserWithAddress($address), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
 
     \expect(\getRequestPayload(1))->toMatchArray([
         'user' => [
@@ -100,7 +173,7 @@ use TrueLayer\Tests\Integration\Mocks\PaymentResponse;
                 'address_line1' => 'The Gilbert',
                 'address_line2' => null,
                 'city' => 'London',
-                'state' => 'London',
+                'state' => 'Greater London',
                 'zip' => 'EC2A 1PX',
                 'country_code' => 'GB',
             ],

--- a/tests/integration/PaymentCreateTest.php
+++ b/tests/integration/PaymentCreateTest.php
@@ -114,7 +114,7 @@ use TrueLayer\Tests\Integration\Mocks\PaymentResponse;
         PaymentResponse::created(),
     ]);
 
-    $factory->payment($factory->newUserWithDateOfBirth("2024-01-01"), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
+    $factory->payment($factory->newUserWithDateOfBirth('2024-01-01'), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
 
     \expect(\getRequestPayload(1))->toMatchArray([
         'user' => [
@@ -123,7 +123,7 @@ use TrueLayer\Tests\Integration\Mocks\PaymentResponse;
             'phone' => '+447837485713',
             'email' => 'alice@truelayer.com',
             'address' => null,
-            'date_of_birth' => "2024-01-01",
+            'date_of_birth' => '2024-01-01',
         ],
     ]);
 });
@@ -133,7 +133,7 @@ use TrueLayer\Tests\Integration\Mocks\PaymentResponse;
         PaymentResponse::created(),
     ]);
 
-    $factory->payment($factory->newUserWithDateOfBirth("invalid data"), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
+    $factory->payment($factory->newUserWithDateOfBirth('invalid data'), $factory->bankTransferMethod($factory->sortCodeBeneficiary()))->create();
 })->throws(TrueLayer\Exceptions\ValidationException::class);
 
 \it('parses payment creation response correctly', function () {


### PR DESCRIPTION
This pull requests adds support for setting the user's address and date of birth. It brings the library in line with TrueLayer's current [API reference](https://docs.truelayer.com/reference/create-payment).