### PR TITLE
[PHP-73] Drop illuminate/encryption in favour of a local copy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "truelayer/signing": "^1.0.0",
         "ramsey/uuid": "^3.7|^4.1",
         "illuminate/support": "^v6.0|^v7.0|^v8.0|^v9.0",
-        "illuminate/encryption": "^v6.0|^v7.0|^v8.0|^v9.0",
         "php-http/discovery": "^1.15.1"
     },
     "suggest": {

--- a/src/Services/Configuration/Config.php
+++ b/src/Services/Configuration/Config.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TrueLayer\Services\Configuration;
 
-use Illuminate\Encryption\Encrypter;
 use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -13,6 +12,7 @@ use TrueLayer\Exceptions\InvalidArgumentException;
 use TrueLayer\Interfaces\Configuration\ConfigInterface;
 use TrueLayer\Interfaces\EncryptedCacheInterface;
 use TrueLayer\Services\Util\EncryptedCache;
+use TrueLayer\Services\Util\Encryption\Encrypter;
 
 abstract class Config implements ConfigInterface
 {

--- a/src/Services/Util/EncryptedCache.php
+++ b/src/Services/Util/EncryptedCache.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace TrueLayer\Services\Util;
 
-use Illuminate\Encryption\Encrypter;
 use Psr\SimpleCache\CacheInterface;
 use TrueLayer\Exceptions\DecryptException;
 use TrueLayer\Exceptions\EncryptException;
 use TrueLayer\Exceptions\InvalidArgumentException;
 use TrueLayer\Interfaces\EncryptedCacheInterface;
+use TrueLayer\Services\Util\Encryption\Encrypter;
 
 final class EncryptedCache implements EncryptedCacheInterface
 {

--- a/src/Services/Util/Encryption/Encrypter.php
+++ b/src/Services/Util/Encryption/Encrypter.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace TrueLayer\Services\Util\Encryption;
+
+use RuntimeException;
+use TrueLayer\Exceptions\DecryptException;
+use TrueLayer\Exceptions\EncryptException;
+
+class Encrypter
+{
+    /**
+     * The encryption key.
+     *
+     * @var string
+     */
+    protected string $key;
+
+    /**
+     * The previous / legacy encryption keys.
+     *
+     * @var array
+     */
+    protected array $previousKeys = [];
+
+    /**
+     * The algorithm used for encryption.
+     *
+     * @var string
+     */
+    protected string $cipher;
+
+    /**
+     * The supported cipher algorithms and their properties.
+     *
+     * @var array
+     */
+    private static array $supportedCiphers = [
+        'aes-128-cbc' => ['size' => 16, 'aead' => false],
+        'aes-256-cbc' => ['size' => 32, 'aead' => false],
+        'aes-128-gcm' => ['size' => 16, 'aead' => true],
+        'aes-256-gcm' => ['size' => 32, 'aead' => true],
+    ];
+
+    /**
+     * Create a new encrypter instance.
+     *
+     * @param string $key
+     * @param string $cipher
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function __construct(string $key, string $cipher = 'aes-128-cbc')
+    {
+        $key = (string) $key;
+
+        if (! static::supported($key, $cipher)) {
+            $ciphers = implode(', ', array_keys(self::$supportedCiphers));
+
+            throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: $ciphers.");
+        }
+
+        $this->key = $key;
+        $this->cipher = $cipher;
+    }
+
+    /**
+     * Determine if the given key and cipher combination is valid.
+     *
+     * @param string $key
+     * @param string $cipher
+     * @return bool
+     */
+    public static function supported(string $key, string $cipher): bool
+    {
+        if (! isset(self::$supportedCiphers[strtolower($cipher)])) {
+            return false;
+        }
+
+        return mb_strlen($key, '8bit') === self::$supportedCiphers[strtolower($cipher)]['size'];
+    }
+
+    /**
+     * Create a new encryption key for the given cipher.
+     *
+     * @param string $cipher
+     * @return string
+     */
+    public static function generateKey(string $cipher): string
+    {
+        return random_bytes(self::$supportedCiphers[strtolower($cipher)]['size'] ?? 32);
+    }
+
+    /**
+     * Encrypt the given value.
+     *
+     * @param mixed $value
+     * @param bool $serialize
+     * @return string
+     *
+     * @throws EncryptException
+     */
+    public function encrypt(mixed $value, bool $serialize = true): string
+    {
+        $iv = random_bytes(openssl_cipher_iv_length(strtolower($this->cipher)));
+
+        $value = \openssl_encrypt(
+            $serialize ? serialize($value) : $value,
+            strtolower($this->cipher), $this->key, 0, $iv, $tag
+        );
+
+        if ($value === false) {
+            throw new EncryptException('Could not encrypt the data.');
+        }
+
+        $iv = base64_encode($iv);
+        $tag = base64_encode($tag ?? '');
+
+        $mac = self::$supportedCiphers[strtolower($this->cipher)]['aead']
+            ? '' // For AEAD-algorithms, the tag / MAC is returned by openssl_encrypt...
+            : $this->hash($iv, $value, $this->key);
+
+        $json = json_encode(compact('iv', 'value', 'mac', 'tag'), JSON_UNESCAPED_SLASHES);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new EncryptException('Could not encrypt the data.');
+        }
+
+        return base64_encode($json);
+    }
+
+    /**
+     * Encrypt a string without serialization.
+     *
+     * @param string $value
+     * @return string
+     *
+     * @throws EncryptException
+     */
+    public function encryptString(string $value): string
+    {
+        return $this->encrypt($value, false);
+    }
+
+    /**
+     * Decrypt the given value.
+     *
+     * @param string $payload
+     * @param bool $unserialize
+     * @return mixed
+     *
+     * @throws DecryptException
+     */
+    public function decrypt(string $payload, bool $unserialize = true): mixed
+    {
+        $payload = $this->getJsonPayload($payload);
+
+        $iv = base64_decode($payload['iv']);
+
+        $this->ensureTagIsValid(
+            $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
+        );
+
+        $decrypted = false;
+
+        // Here we will decrypt the value. If we are able to successfully decrypt it
+        // we will then unserialize it and return it out to the caller. If we are
+        // unable to decrypt this value we will throw out an exception message.
+        foreach ($this->getAllKeys() as $key) {
+            $decrypted = \openssl_decrypt(
+                $payload['value'], strtolower($this->cipher), $key, 0, $iv, $tag ?? ''
+            );
+
+            if ($decrypted !== false) {
+                break;
+            }
+        }
+
+        if ($decrypted === false) {
+            throw new DecryptException('Could not decrypt the data.');
+        }
+
+        return $unserialize ? unserialize($decrypted) : $decrypted;
+    }
+
+    /**
+     * Decrypt the given string without unserialization.
+     *
+     * @param string $payload
+     * @return string
+     *
+     * @throws DecryptException
+     */
+    public function decryptString(string $payload): string
+    {
+        return $this->decrypt($payload, false);
+    }
+
+    /**
+     * Create a MAC for the given value.
+     *
+     * @param string $iv
+     * @param  mixed  $value
+     * @param string $key
+     * @return string
+     */
+    protected function hash(string $iv, mixed $value, string $key): string
+    {
+        return hash_hmac('sha256', $iv.$value, $key);
+    }
+
+    /**
+     * Get the JSON array from the given payload.
+     *
+     * @param string $payload
+     * @return array
+     *
+     * @throws DecryptException
+     */
+    protected function getJsonPayload(string $payload): array
+    {
+        if (! is_string($payload)) {
+            throw new DecryptException('The payload is invalid.');
+        }
+
+        $payload = json_decode(base64_decode($payload), true);
+
+        // If the payload is not valid JSON or does not have the proper keys set we will
+        // assume it is invalid and bail out of the routine since we will not be able
+        // to decrypt the given value. We'll also check the MAC for this encryption.
+        if (! $this->validPayload($payload)) {
+            throw new DecryptException('The payload is invalid.');
+        }
+
+        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && ! $this->validMac($payload)) {
+            throw new DecryptException('The MAC is invalid.');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Verify that the encryption payload is valid.
+     *
+     * @param  mixed  $payload
+     * @return bool
+     */
+    protected function validPayload(mixed $payload): bool
+    {
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        foreach (['iv', 'value', 'mac'] as $item) {
+            if (! isset($payload[$item]) || ! is_string($payload[$item])) {
+                return false;
+            }
+        }
+
+        if (isset($payload['tag']) && ! is_string($payload['tag'])) {
+            return false;
+        }
+
+        return strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
+    }
+
+    /**
+     * Determine if the MAC for the given payload is valid.
+     *
+     * @param  array  $payload
+     * @return bool
+     */
+    protected function validMac(array $payload): bool
+    {
+        foreach ($this->getAllKeys() as $key) {
+            $valid = hash_equals(
+                $this->hash($payload['iv'], $payload['value'], $key), $payload['mac']
+            );
+
+            if ($valid === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Ensure the given tag is a valid tag given the selected cipher.
+     *
+     * @param string|null $tag
+     * @return void
+     * @throws DecryptException
+     */
+    protected function ensureTagIsValid(string|null $tag): void
+    {
+        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
+            throw new DecryptException('Could not decrypt the data.');
+        }
+
+        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
+            throw new DecryptException('Unable to use tag because the cipher algorithm does not support AEAD.');
+        }
+    }
+
+    /**
+     * Get the encryption key that the encrypter is currently using.
+     *
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Get the current encryption key and all previous encryption keys.
+     *
+     * @return array
+     */
+    public function getAllKeys(): array
+    {
+        return [$this->key, ...$this->previousKeys];
+    }
+
+    /**
+     * Get the previous encryption keys.
+     *
+     * @return array
+     */
+    public function getPreviousKeys(): array
+    {
+        return $this->previousKeys;
+    }
+
+    /**
+     * Set the previous / legacy encryption keys that should be utilized if decryption fails.
+     *
+     * @param array $keys
+     * @return $this
+     */
+    public function previousKeys(array $keys): self
+    {
+        foreach ($keys as $key) {
+            if (! static::supported($key, $this->cipher)) {
+                $ciphers = implode(', ', array_keys(self::$supportedCiphers));
+
+                throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: $ciphers.");
+            }
+        }
+
+        $this->previousKeys = $keys;
+
+        return $this;
+    }
+}

--- a/src/Services/Util/Encryption/LICENSE.md
+++ b/src/Services/Util/Encryption/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Services/Util/Encryption/README.md
+++ b/src/Services/Util/Encryption/README.md
@@ -1,0 +1,2 @@
+Pull request # adds a local copy of the [illuminate/encryption](https://github.com/illuminate/encryption) package in
+order to reduce the number of dependencies and the underlying contraints.

--- a/tests/integration/ApiClient/AccessTokenTest.php
+++ b/tests/integration/ApiClient/AccessTokenTest.php
@@ -77,7 +77,7 @@ use TrueLayer\Tests\Integration\Mocks;
 \it('reuses cached access token across requests',
     function () {
         $okResponse = new Response(200);
-        $encrypter = new \Illuminate\Encryption\Encrypter(\hex2bin('31c8d81a110849f83131541b9f67c3cba9c7e0bb103bc4dd19377f0fdf2d924b'), \TrueLayer\Constants\Encryption::ALGORITHM);
+        $encrypter = new \TrueLayer\Services\Util\Encryption\Encrypter(\hex2bin('31c8d81a110849f83131541b9f67c3cba9c7e0bb103bc4dd19377f0fdf2d924b'), \TrueLayer\Constants\Encryption::ALGORITHM);
 
         $cacheMock = Mockery::mock(\Psr\SimpleCache\CacheInterface::class);
         $cacheMock->shouldReceive('has')->andReturnTrue();
@@ -108,7 +108,7 @@ use TrueLayer\Tests\Integration\Mocks;
 
 \it('fetches a new token if the cached one is expired', function () {
     $okResponse = new Response(200);
-    $encrypter = new \Illuminate\Encryption\Encrypter(\hex2bin('31c8d81a110849f83131541b9f67c3cba9c7e0bb103bc4dd19377f0fdf2d924b'), \TrueLayer\Constants\Encryption::ALGORITHM);
+    $encrypter = new \TrueLayer\Services\Util\Encryption\Encrypter(\hex2bin('31c8d81a110849f83131541b9f67c3cba9c7e0bb103bc4dd19377f0fdf2d924b'), \TrueLayer\Constants\Encryption::ALGORITHM);
 
     $cacheMock = Mockery::mock(\Psr\SimpleCache\CacheInterface::class);
     $cacheMock->shouldReceive('has')->andReturnTrue();

--- a/tests/integration/WebhookCacheTest.php
+++ b/tests/integration/WebhookCacheTest.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Carbon;
 use Jose\Component\KeyManagement\JWKFactory;
 use TrueLayer\Constants\Encryption;
 use TrueLayer\Exceptions\WebhookVerificationFailedException;
+use TrueLayer\Services\Util\Encryption\Encrypter;
 use TrueLayer\Tests\Integration\Mocks\Signing;
 use TrueLayer\Tests\Integration\Mocks\WebhookPayload;
 


### PR DESCRIPTION
This pull request drops the `illuminate/encryption` package dependency in favour of a local copy. This makes the dependency tree smaller and increases compatibility with frameworks like Magento2 and Wordpress