### PR TITLE
PHP-79: Add additional countries to constants and fix empty excluded …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-04-24
+
+### Added
+
+- Additional supported countries in TrueLayer\Constants\Countries
+
+### Fixed
+
+- Using provider filters without specifying an excluded provider id would return an error
+
 ## [2.0.0] - 2024-03-26
 
 ### Changed

--- a/src/Constants/Countries.php
+++ b/src/Constants/Countries.php
@@ -6,7 +6,20 @@ namespace TrueLayer\Constants;
 
 class Countries
 {
-    public const GB = 'GB';
+    public const AT = 'AT';
+    public const BE = 'BE';
+    public const DE = 'DE';
+    public const DK = 'DK';
+    public const ES = 'ES';
+    public const FI = 'FI';
     public const FR = 'FR';
+    public const GB = 'GB';
     public const IE = 'IE';
+    public const IT = 'IT';
+    public const LT = 'LT';
+    public const NL = 'NL';
+    public const NO = 'NO';
+    public const PL = 'PL';
+    public const PT = 'PT';
+    public const RO = 'RO';
 }

--- a/src/Entities/Provider/ProviderSelection/ProviderFilter.php
+++ b/src/Entities/Provider/ProviderSelection/ProviderFilter.php
@@ -96,9 +96,9 @@ class ProviderFilter extends Entity implements ProviderFilterInterface
     /**
      * @return array|string[]
      */
-    public function getExcludesProviderIds(): array
+    public function getExcludesProviderIds(): ?array
     {
-        return $this->excludesProviderIds ?? [];
+        return $this->excludesProviderIds ?? null;
     }
 
     /**

--- a/tests/integration/PaymentCreateTest.php
+++ b/tests/integration/PaymentCreateTest.php
@@ -48,7 +48,7 @@ use TrueLayer\Tests\Integration\Mocks\PaymentResponse;
                         'mock-payments-gb-redirect',
                     ],
                     'excludes' => [
-                        'provider_ids' => [],
+                        'provider_ids' => null,
                     ],
                 ],
             ],


### PR DESCRIPTION
…provider ids being rejected by the api