### PR TITLE
[ACL-26] Payment risk assessment

### DIFF
--- a/config/bindings.php
+++ b/config/bindings.php
@@ -16,6 +16,7 @@ return [
     Interfaces\Beneficiary\ExternalAccountBeneficiaryInterface::class => Entities\Beneficiary\ExternalAccountBeneficiary::class,
 
     Interfaces\Payment\PaymentRequestInterface::class => Entities\Payment\PaymentRequest::class,
+    Interfaces\Payment\PaymentRiskAssessmentInterface::class => Entities\Payment\PaymentRiskAssessment::class,
     Interfaces\Payment\PaymentCreatedInterface::class => Entities\Payment\PaymentCreated::class,
     Interfaces\Payment\PaymentAuthorizationRequiredInterface::class => Entities\Payment\PaymentRetrieved\PaymentAuthorizationRequired::class,
     Interfaces\Payment\PaymentAuthorizingInterface::class => Entities\Payment\PaymentRetrieved\PaymentAuthorizing::class,

--- a/src/Entities/Payment/PaymentRequest.php
+++ b/src/Entities/Payment/PaymentRequest.php
@@ -12,6 +12,7 @@ use TrueLayer\Exceptions\SignerException;
 use TrueLayer\Interfaces\HasApiFactoryInterface;
 use TrueLayer\Interfaces\Payment\PaymentCreatedInterface;
 use TrueLayer\Interfaces\Payment\PaymentRequestInterface;
+use TrueLayer\Interfaces\Payment\PaymentRiskAssessmentInterface;
 use TrueLayer\Interfaces\PaymentMethod\PaymentMethodInterface;
 use TrueLayer\Interfaces\RequestOptionsInterface;
 use TrueLayer\Interfaces\UserInterface;
@@ -47,6 +48,11 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
     protected array $metadata;
 
     /**
+     * @var PaymentRiskAssessmentInterface
+     */
+    protected PaymentRiskAssessmentInterface $riskAssessment;
+
+    /**
      * @var RequestOptionsInterface|null
      */
     protected ?RequestOptionsInterface $requestOptions = null;
@@ -56,6 +62,7 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
      */
     protected array $casts = [
         'payment_method' => PaymentMethodInterface::class,
+        'risk_assessment' => PaymentRiskAssessmentInterface::class,
         'user' => UserInterface::class,
     ];
 
@@ -67,6 +74,7 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
         'currency',
         'metadata',
         'payment_method',
+        'risk_assessment',
         'user',
     ];
 
@@ -116,6 +124,20 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
         $this->paymentMethod = $paymentMethod;
 
         return $this;
+    }
+
+    /**
+     * @param PaymentRiskAssessmentInterface|null $riskAssessment
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return PaymentRiskAssessmentInterface
+     */
+    public function riskAssessment(?PaymentRiskAssessmentInterface $riskAssessment = null): PaymentRiskAssessmentInterface
+    {
+        $this->riskAssessment = $riskAssessment ?: $this->entityFactory->make(PaymentRiskAssessmentInterface::class);
+
+        return $this->riskAssessment;
     }
 
     /**

--- a/src/Entities/Payment/PaymentRiskAssessment.php
+++ b/src/Entities/Payment/PaymentRiskAssessment.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrueLayer\Entities\Payment;
+
+use TrueLayer\Entities\Entity;
+use TrueLayer\Interfaces\Payment\PaymentRiskAssessmentInterface;
+
+class PaymentRiskAssessment extends Entity implements PaymentRiskAssessmentInterface
+{
+    /**
+     * @var string
+     */
+    protected string $segment;
+
+    /**
+     * @var string[]
+     */
+    protected array $arrayFields = [
+        'segment',
+    ];
+
+    /**
+     * @return string|null
+     */
+    public function getSegment(): ?string
+    {
+        return $this->segment;
+    }
+
+    /**
+     * @param string $segment
+     *
+     * @return PaymentRiskAssessmentInterface
+     */
+    public function segment(string $segment): PaymentRiskAssessmentInterface
+    {
+        $this->segment = $segment;
+
+        return $this;
+    }
+}

--- a/src/Interfaces/Payment/PaymentRequestInterface.php
+++ b/src/Interfaces/Payment/PaymentRequestInterface.php
@@ -40,6 +40,13 @@ interface PaymentRequestInterface extends HasAttributesInterface
     public function paymentMethod(PaymentMethodInterface $paymentMethod): PaymentRequestInterface;
 
     /**
+     * @param PaymentRiskAssessmentInterface|null $riskAssessment
+     *
+     * @return PaymentRiskAssessmentInterface
+     */
+    public function riskAssessment(?PaymentRiskAssessmentInterface $riskAssessment): PaymentRiskAssessmentInterface;
+
+    /**
      * @param UserInterface $user
      *
      * @return PaymentRequestInterface

--- a/src/Interfaces/Payment/PaymentRiskAssessmentInterface.php
+++ b/src/Interfaces/Payment/PaymentRiskAssessmentInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrueLayer\Interfaces\Payment;
+
+interface PaymentRiskAssessmentInterface
+{
+    /**
+     * @return string|null
+     */
+    public function getSegment(): ?string;
+
+    /**
+     * @param string $segment
+     *
+     * @return PaymentRiskAssessmentInterface
+     */
+    public function segment(string $segment): PaymentRiskAssessmentInterface;
+}


### PR DESCRIPTION
This PR adds support for the `risk_assessment` field on the payment create request. I've intentionally left it out of the readme file because it's a niche setting that customers need to get in touch with TrueLayer before using.