### PR TITLE
Attributes & reflection magic

### DIFF
--- a/src/Attributes/ArrayShape.php
+++ b/src/Attributes/ArrayShape.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrueLayer\Attributes;
+
+#[\Attribute]
+class ArrayShape
+{
+    public function __construct(public string $type)
+    {
+    }
+}

--- a/src/Attributes/Field.php
+++ b/src/Attributes/Field.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TrueLayer\Attributes;
+
+#[\Attribute]
+class Field
+{
+    public function __construct(public ?string $name = null)
+    {
+    }
+}

--- a/src/Entities/Hpp.php
+++ b/src/Entities/Hpp.php
@@ -52,19 +52,6 @@ final class Hpp extends Entity implements HppInterface
     #[Field('c_tertiary')]
     protected string $tertiaryColour;
 
-//    /**
-//     * @var string[]
-//     */
-//    protected array $arrayFields = [
-//        'base_url',
-//        'payment_id',
-//        'resource_token' => 'resource_token',
-//        'return_uri',
-//        'c_primary' => 'primary_colour',
-//        'c_secondary' => 'secondary_colour',
-//        'c_tertiary' => 'tertiary_colour',
-//    ];
-
     /**
      * @param string $baseUrl
      *

--- a/src/Entities/Hpp.php
+++ b/src/Entities/Hpp.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Interfaces\HppInterface;
 use TrueLayer\Services\Util\Str;
 
@@ -12,50 +13,57 @@ final class Hpp extends Entity implements HppInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $baseUrl;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $paymentId;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $resourceToken;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $returnUri;
 
     /**
      * @var string
      */
+    #[Field('c_primary')]
     protected string $primaryColour;
 
     /**
      * @var string
      */
+    #[Field('c_secondary')]
     protected string $secondaryColour;
 
     /**
      * @var string
      */
+    #[Field('c_tertiary')]
     protected string $tertiaryColour;
 
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'base_url',
-        'payment_id',
-        'resource_token' => 'resource_token',
-        'return_uri',
-        'c_primary' => 'primary_colour',
-        'c_secondary' => 'secondary_colour',
-        'c_tertiary' => 'tertiary_colour',
-    ];
+//    /**
+//     * @var string[]
+//     */
+//    protected array $arrayFields = [
+//        'base_url',
+//        'payment_id',
+//        'resource_token' => 'resource_token',
+//        'return_uri',
+//        'c_primary' => 'primary_colour',
+//        'c_secondary' => 'secondary_colour',
+//        'c_tertiary' => 'tertiary_colour',
+//    ];
 
     /**
      * @param string $baseUrl
@@ -206,8 +214,8 @@ final class Hpp extends Entity implements HppInterface
         unset($params['base_url']);
 
         return $this->baseUrl . '#' . \http_build_query(
-            $params, '', '&', PHP_QUERY_RFC3986
-        );
+                $params, '', '&', PHP_QUERY_RFC3986
+            );
     }
 
     /**

--- a/src/Entities/Payment/AuthorizationFlow/Action.php
+++ b/src/Entities/Payment/AuthorizationFlow/Action.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\Action\ActionInterface;
 
@@ -12,14 +13,8 @@ class Action extends Entity implements ActionInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $type;
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'type',
-    ];
 
     /**
      * @return string

--- a/src/Entities/Payment/AuthorizationFlow/Action/ProviderSelectionAction.php
+++ b/src/Entities/Payment/AuthorizationFlow/Action/ProviderSelectionAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow\Action;
 
+use TrueLayer\Attributes\ArrayShape;
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Payment\AuthorizationFlow\Action;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\Action\ProviderSelectionActionInterface;
 use TrueLayer\Interfaces\Provider\ProviderInterface;
@@ -13,22 +15,8 @@ class ProviderSelectionAction extends Action implements ProviderSelectionActionI
     /**
      * @var ProviderInterface[]
      */
+    #[Field, ArrayShape(ProviderInterface::class)]
     protected array $providers = [];
-
-    /**
-     * @var array|string[]
-     */
-    protected array $arrayFields = [
-        'type',
-        'providers',
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected array $casts = [
-        'providers.*' => ProviderInterface::class,
-    ];
 
     /**
      * @return ProviderInterface[]

--- a/src/Entities/Payment/AuthorizationFlow/Action/RedirectAction.php
+++ b/src/Entities/Payment/AuthorizationFlow/Action/RedirectAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow\Action;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Payment\AuthorizationFlow\Action;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\Action\RedirectActionInterface;
 use TrueLayer\Interfaces\Provider\ProviderInterface;
@@ -13,28 +14,14 @@ class RedirectAction extends Action implements RedirectActionInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $uri;
 
     /**
      * @var ProviderInterface
      */
+    #[Field('metadata')]
     protected ProviderInterface $provider;
-
-    /**
-     * @var array|string[]
-     */
-    protected array $casts = [
-        'metadata' => ProviderInterface::class,
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'type',
-        'uri',
-        'metadata' => 'provider',
-    ];
 
     /**
      * @return string

--- a/src/Entities/Payment/AuthorizationFlow/AuthorizationFlow.php
+++ b/src/Entities/Payment/AuthorizationFlow/AuthorizationFlow.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\ActionInterface;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\AuthorizationFlowInterface;
@@ -14,22 +15,14 @@ final class AuthorizationFlow extends Entity implements AuthorizationFlowInterfa
     /**
      * @var ActionInterface
      */
+    #[Field('actions.next')]
     protected ActionInterface $nextAction;
 
     /**
      * @var ConfigurationInterface
      */
+    #[Field]
     protected ConfigurationInterface $configuration;
-
-    protected array $casts = [
-        'actions.next' => ActionInterface::class,
-        'configuration' => ConfigurationInterface::class,
-    ];
-
-    protected array $arrayFields = [
-        'actions.next' => 'next_action',
-        'configuration' => 'configuration',
-    ];
 
     /**
      * @return ConfigurationInterface|null

--- a/src/Entities/Payment/AuthorizationFlow/AuthorizationFlowAuthorizationFailed.php
+++ b/src/Entities/Payment/AuthorizationFlow/AuthorizationFlowAuthorizationFailed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\AuthorizationFlowAuthorizationFailedInterface;
 
 final class AuthorizationFlowAuthorizationFailed extends AuthorizationFlowResponse implements AuthorizationFlowAuthorizationFailedInterface
@@ -11,20 +12,14 @@ final class AuthorizationFlowAuthorizationFailed extends AuthorizationFlowRespon
     /**
      * @var string
      */
+    #[Field]
     protected string $failureStage;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $failureReason;
-
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'failure_stage',
-            'failure_reason',
-        ]);
-    }
 
     /**
      * @return string

--- a/src/Entities/Payment/AuthorizationFlow/AuthorizationFlowResponse.php
+++ b/src/Entities/Payment/AuthorizationFlow/AuthorizationFlowResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\ActionInterface;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\AuthorizationFlowInterface;
@@ -14,27 +15,14 @@ abstract class AuthorizationFlowResponse extends Entity implements Authorization
     /**
      * @var string
      */
+    #[Field]
     protected string $status;
 
     /**
      * @var AuthorizationFlowInterface
      */
+    #[Field]
     protected AuthorizationFlowInterface $authorizationFlow;
-
-    /**
-     * @var string[]
-     */
-    protected array $casts = [
-        'authorization_flow' => AuthorizationFlowInterface::class,
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'status',
-        'authorization_flow',
-    ];
 
     /**
      * @return ActionInterface|null

--- a/src/Entities/Payment/AuthorizationFlow/Configuration.php
+++ b/src/Entities/Payment/AuthorizationFlow/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\ConfigurationInterface;
 
@@ -12,14 +13,8 @@ class Configuration extends Entity implements ConfigurationInterface
     /**
      * @var string
      */
+    #[Field('redirect.return_uri')]
     protected string $redirectReturnUri;
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'redirect.return_uri' => 'redirect_return_uri',
-    ];
 
     /**
      * @return string|null

--- a/src/Entities/Payment/AuthorizationFlow/StartAuthorizationFlowRequest.php
+++ b/src/Entities/Payment/AuthorizationFlow/StartAuthorizationFlowRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\AuthorizationFlow;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Constants\FormInputTypes;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Exceptions\ApiRequestJsonSerializationException;
@@ -27,41 +28,38 @@ final class StartAuthorizationFlowRequest extends Entity implements StartAuthori
     /**
      * @var \ArrayObject<string, mixed>|null
      */
+    #[Field]
     protected ?\ArrayObject $userAccountSelection;
 
     /**
      * @var \ArrayObject<string, mixed>|null
      */
+    #[Field]
     protected ?\ArrayObject $providerSelection;
 
     /**
      * @var \ArrayObject<string, mixed>|null
      */
+    #[Field]
     protected ?\ArrayObject $schemeSelection;
 
     /**
      * @var string
      */
+    #[Field('redirect.direct_return_uri')]
     protected string $directReturnUri;
 
     /**
      * @var string
      */
+    #[Field('redirect.return_uri')]
     protected string $returnUri;
 
     /**
      * @var string[]
      */
+    #[Field('form.input_types')]
     protected array $formInputTypes = [];
-
-    protected array $arrayFields = [
-        'user_account_selection',
-        'provider_selection',
-        'scheme_selection',
-        'redirect.return_uri' => 'returnUri',
-        'redirect.direct_return_uri' => 'directReturnUri',
-        'form.input_types' => 'formInputTypes',
-    ];
 
     /**
      * @param string $paymentId
@@ -158,12 +156,12 @@ final class StartAuthorizationFlowRequest extends Entity implements StartAuthori
     }
 
     /**
-     * @throws ApiResponseUnsuccessfulException
+     * @return AuthorizationFlowResponseInterface
      * @throws InvalidArgumentException
      * @throws SignerException
      * @throws ApiRequestJsonSerializationException
      *
-     * @return AuthorizationFlowResponseInterface
+     * @throws ApiResponseUnsuccessfulException
      */
     public function start(): AuthorizationFlowResponseInterface
     {

--- a/src/Entities/Payment/PaymentCreated.php
+++ b/src/Entities/Payment/PaymentCreated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Exceptions\ApiRequestJsonSerializationException;
 use TrueLayer\Exceptions\ApiResponseUnsuccessfulException;
@@ -24,27 +25,21 @@ final class PaymentCreated extends Entity implements PaymentCreatedInterface, Ha
     /**
      * @var string
      */
+    #[Field]
     protected string $id;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $resourceToken;
 
     /**
      * @var string
      */
+    #[Field('user.id')]
     protected string $userId;
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'id',
-        'resource_token',
-        'user.id' => 'user_id',
-    ];
-
+    
     /**
      * @return string
      */
@@ -70,9 +65,9 @@ final class PaymentCreated extends Entity implements PaymentCreatedInterface, Ha
     }
 
     /**
+     * @return HppInterface
      * @throws InvalidArgumentException
      *
-     * @return HppInterface
      */
     public function hostedPaymentsPage(): HppInterface
     {
@@ -84,19 +79,19 @@ final class PaymentCreated extends Entity implements PaymentCreatedInterface, Ha
     /**
      * @param string $returnUri
      *
-     * @throws SignerException
+     * @return AuthorizationFlowAuthorizingInterface
+     *
      * @throws ApiRequestJsonSerializationException
      * @throws ApiResponseUnsuccessfulException
      * @throws InvalidArgumentException
      *
-     * @return AuthorizationFlowAuthorizingInterface
-     *
+     * @throws SignerException
      * @deprecated
      */
     public function startAuthorization(string $returnUri): AuthorizationFlowAuthorizingInterface
     {
         $data = $this->getApiFactory()->paymentsApi()->startAuthorizationFlow($this->getId(), [
-            'provider_selection' => (object) [],
+            'provider_selection' => (object)[],
             'redirect' => ['return_uri' => $returnUri],
         ]);
 
@@ -104,9 +99,9 @@ final class PaymentCreated extends Entity implements PaymentCreatedInterface, Ha
     }
 
     /**
+     * @return StartAuthorizationFlowRequestInterface
      * @throws InvalidArgumentException
      *
-     * @return StartAuthorizationFlowRequestInterface
      */
     public function authorizationFlow(): StartAuthorizationFlowRequestInterface
     {
@@ -115,12 +110,12 @@ final class PaymentCreated extends Entity implements PaymentCreatedInterface, Ha
     }
 
     /**
-     * @throws SignerException
+     * @return PaymentRetrievedInterface
      * @throws ApiRequestJsonSerializationException
      * @throws ApiResponseUnsuccessfulException
      * @throws InvalidArgumentException
      *
-     * @return PaymentRetrievedInterface
+     * @throws SignerException
      */
     public function getDetails(): PaymentRetrievedInterface
     {

--- a/src/Entities/Payment/PaymentMethod/BankTransferPaymentMethod.php
+++ b/src/Entities/Payment/PaymentMethod/BankTransferPaymentMethod.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\PaymentMethod;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Constants\PaymentMethods;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Exceptions\InvalidArgumentException;
@@ -17,41 +18,26 @@ class BankTransferPaymentMethod extends Entity implements BankTransferPaymentMet
     /**
      * @var string
      */
+    #[Field]
     protected string $type;
 
     /**
      * @var BeneficiaryInterface
      */
+    #[Field]
     protected BeneficiaryInterface $beneficiary;
 
     /**
      * @var ProviderSelectionInterface
      */
+    #[Field]
     protected ProviderSelectionInterface $providerSelection;
 
     /**
      * @var \stdClass|null
      */
+    #[Field]
     protected ?\stdClass $retry;
-
-    /**
-     * @var string[]
-     */
-    protected array $casts = [
-        'provider_selection' => ProviderSelectionInterface::class,
-        'beneficiary' => BeneficiaryInterface::class,
-        'retry' => \stdClass::class,
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'type',
-        'beneficiary',
-        'provider_selection',
-        'retry',
-    ];
 
     /**
      * @param BeneficiaryInterface $beneficiary
@@ -86,9 +72,9 @@ class BankTransferPaymentMethod extends Entity implements BankTransferPaymentMet
     }
 
     /**
+     * @return ProviderSelectionInterface
      * @throws InvalidArgumentException
      *
-     * @return ProviderSelectionInterface
      */
     public function getProviderSelection(): ProviderSelectionInterface
     {
@@ -109,7 +95,7 @@ class BankTransferPaymentMethod extends Entity implements BankTransferPaymentMet
     {
         $retry = $this->retry ?? null;
 
-        return (bool) $retry;
+        return (bool)$retry;
     }
 
     /**

--- a/src/Entities/Payment/PaymentRequest.php
+++ b/src/Entities/Payment/PaymentRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Exceptions\ApiRequestJsonSerializationException;
 use TrueLayer\Exceptions\ApiResponseUnsuccessfulException;
@@ -25,58 +26,43 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
     /**
      * @var int
      */
+    #[Field]
     protected int $amountInMinor;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $currency;
 
     /**
      * @var PaymentMethodInterface
      */
+    #[Field]
     protected PaymentMethodInterface $paymentMethod;
 
     /**
      * @var UserInterface
      */
+    #[Field]
     protected UserInterface $user;
 
     /**
      * @var array<string, string>
      */
+    #[Field]
     protected array $metadata;
 
     /**
      * @var PaymentRiskAssessmentInterface
      */
+    #[Field]
     protected PaymentRiskAssessmentInterface $riskAssessment;
 
     /**
      * @var RequestOptionsInterface|null
      */
     protected ?RequestOptionsInterface $requestOptions = null;
-
-    /**
-     * @var string[]
-     */
-    protected array $casts = [
-        'payment_method' => PaymentMethodInterface::class,
-        'risk_assessment' => PaymentRiskAssessmentInterface::class,
-        'user' => UserInterface::class,
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'amount_in_minor',
-        'currency',
-        'metadata',
-        'payment_method',
-        'risk_assessment',
-        'user',
-    ];
 
     /**
      * @param int $amount
@@ -129,9 +115,9 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
     /**
      * @param PaymentRiskAssessmentInterface|null $riskAssessment
      *
+     * @return PaymentRiskAssessmentInterface
      * @throws InvalidArgumentException
      *
-     * @return PaymentRiskAssessmentInterface
      */
     public function riskAssessment(?PaymentRiskAssessmentInterface $riskAssessment = null): PaymentRiskAssessmentInterface
     {
@@ -165,12 +151,12 @@ final class PaymentRequest extends Entity implements PaymentRequestInterface, Ha
     }
 
     /**
-     * @throws ApiResponseUnsuccessfulException
+     * @return PaymentCreatedInterface
      * @throws InvalidArgumentException
      * @throws SignerException
      * @throws ApiRequestJsonSerializationException
      *
-     * @return PaymentCreatedInterface
+     * @throws ApiResponseUnsuccessfulException
      */
     public function create(): PaymentCreatedInterface
     {

--- a/src/Entities/Payment/PaymentRetrieved.php
+++ b/src/Entities/Payment/PaymentRetrieved.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Constants\PaymentStatus;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\PaymentRetrievedInterface;
@@ -14,64 +15,50 @@ class PaymentRetrieved extends Entity implements PaymentRetrievedInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $id;
 
     /**
      * @var int
      */
+    #[Field]
     protected int $amountInMinor;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $currency;
 
     /**
      * @var array<string, string>
      */
+    #[Field]
     protected array $metadata;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $status;
 
     /**
      * @var PaymentMethodInterface
      */
+    #[Field]
     protected PaymentMethodInterface $paymentMethod;
 
     /**
      * @var string
      */
+    #[Field('user.id')]
     protected string $userId;
 
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $createdAt;
-
-    /**
-     * @var class-string[]
-     */
-    protected array $casts = [
-        'payment_method' => PaymentMethodInterface::class,
-        'created_at' => \DateTimeInterface::class,
-    ];
-
-    /**
-     * @return string[]
-     */
-    protected array $arrayFields = [
-        'id',
-        'status',
-        'created_at',
-        'amount_in_minor',
-        'currency',
-        'metadata',
-        'user.id' => 'user_id',
-        'payment_method',
-    ];
 
     /**
      * @return string

--- a/src/Entities/Payment/PaymentRetrieved/PaymentAuthorizing.php
+++ b/src/Entities/Payment/PaymentRetrieved/PaymentAuthorizing.php
@@ -14,8 +14,6 @@ final class PaymentAuthorizing extends _PaymentWithAuthorizationConfig implement
      */
     public function getAuthorizationFlowNextAction(): ?ActionInterface
     {
-        return $this->getAuthorizationFlow()
-            ? $this->getAuthorizationFlow()->getNextAction()
-            : null;
+        return $this->getAuthorizationFlow()?->getNextAction();
     }
 }

--- a/src/Entities/Payment/PaymentRetrieved/PaymentExecuted.php
+++ b/src/Entities/Payment/PaymentRetrieved/PaymentExecuted.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\PaymentRetrieved;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Interfaces\Payment\PaymentExecutedInterface;
 
 final class PaymentExecuted extends _PaymentWithAuthorizationConfig implements PaymentExecutedInterface
@@ -11,27 +12,8 @@ final class PaymentExecuted extends _PaymentWithAuthorizationConfig implements P
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $executedAt;
-
-    /**
-     * @return mixed[]
-     */
-    protected function casts(): array
-    {
-        return \array_merge_recursive(parent::casts(), [
-            'executed_at' => \DateTimeInterface::class,
-        ]);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'executed_at',
-        ]);
-    }
 
     /**
      * @return \DateTimeInterface

--- a/src/Entities/Payment/PaymentRetrieved/PaymentFailure.php
+++ b/src/Entities/Payment/PaymentRetrieved/PaymentFailure.php
@@ -4,45 +4,28 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\PaymentRetrieved;
 
+use TrueLayer\Attributes\Field;
+
 abstract class PaymentFailure extends _PaymentWithAuthorizationConfig
 {
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $failedAt;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $failureStage;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $failureReason;
-
-    /**
-     * @return mixed[]
-     */
-    protected function casts(): array
-    {
-        return \array_merge_recursive(parent::casts(), [
-            'failed_at' => \DateTimeInterface::class,
-        ]);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'failed_at',
-            'failure_stage',
-            'failure_reason',
-        ]);
-    }
-
+    
     /**
      * @return \DateTimeInterface
      */

--- a/src/Entities/Payment/PaymentRetrieved/PaymentSettled.php
+++ b/src/Entities/Payment/PaymentRetrieved/PaymentSettled.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\PaymentRetrieved;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Exceptions\ApiRequestJsonSerializationException;
 use TrueLayer\Exceptions\ApiResponseUnsuccessfulException;
 use TrueLayer\Exceptions\InvalidArgumentException;
@@ -22,41 +23,20 @@ final class PaymentSettled extends _PaymentWithAuthorizationConfig implements Pa
     /**
      * @var PaymentSourceInterface
      */
+    #[Field]
     protected PaymentSourceInterface $paymentSource;
 
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $executedAt;
 
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $settledAt;
-
-    /**
-     * @return mixed[]
-     */
-    protected function casts(): array
-    {
-        return \array_merge_recursive(parent::casts(), [
-            'executed_at' => \DateTimeInterface::class,
-            'settled_at' => \DateTimeInterface::class,
-            'payment_source' => PaymentSourceInterface::class,
-        ]);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'payment_source',
-            'executed_at',
-            'settled_at',
-        ]);
-    }
 
     /**
      * @return \DateTimeInterface
@@ -83,9 +63,9 @@ final class PaymentSettled extends _PaymentWithAuthorizationConfig implements Pa
     }
 
     /**
+     * @return RefundRequestInterface
      * @throws InvalidArgumentException
      *
-     * @return RefundRequestInterface
      */
     public function refund(): RefundRequestInterface
     {
@@ -96,12 +76,12 @@ final class PaymentSettled extends _PaymentWithAuthorizationConfig implements Pa
     /**
      * @param string $refundId
      *
-     * @throws InvalidArgumentException
+     * @return RefundRetrievedInterface
      * @throws SignerException
      * @throws ApiRequestJsonSerializationException
      * @throws ApiResponseUnsuccessfulException
      *
-     * @return RefundRetrievedInterface
+     * @throws InvalidArgumentException
      */
     public function getRefund(string $refundId): RefundRetrievedInterface
     {
@@ -111,12 +91,12 @@ final class PaymentSettled extends _PaymentWithAuthorizationConfig implements Pa
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @return RefundRetrievedInterface[]
      * @throws SignerException
      * @throws ApiRequestJsonSerializationException
      * @throws ApiResponseUnsuccessfulException
      *
-     * @return RefundRetrievedInterface[]
+     * @throws InvalidArgumentException
      */
     public function getRefunds(): array
     {

--- a/src/Entities/Payment/PaymentRetrieved/PaymentSource.php
+++ b/src/Entities/Payment/PaymentRetrieved/PaymentSource.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\PaymentRetrieved;
 
+use TrueLayer\Attributes\ArrayShape;
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\AccountIdentifier\AccountIdentifierInterface;
 use TrueLayer\Interfaces\Payment\PaymentSourceInterface;
@@ -13,33 +15,20 @@ final class PaymentSource extends Entity implements PaymentSourceInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $id;
 
     /**
      * @var AccountIdentifierInterface[]
      */
+    #[Field, ArrayShape(AccountIdentifierInterface::class)]
     protected array $accountIdentifiers;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $accountHolderName;
-
-    /**
-     * @var string[]
-     */
-    protected array $casts = [
-        'account_identifiers.*' => AccountIdentifierInterface::class,
-    ];
-
-    /**
-     * @var array|string[]
-     */
-    protected array $arrayFields = [
-        'id',
-        'account_identifiers',
-        'account_holder_name',
-    ];
 
     /**
      * @return string|null

--- a/src/Entities/Payment/PaymentRetrieved/_PaymentWithAuthorizationConfig.php
+++ b/src/Entities/Payment/PaymentRetrieved/_PaymentWithAuthorizationConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\PaymentRetrieved;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Payment\PaymentRetrieved;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\AuthorizationFlowInterface;
 use TrueLayer\Interfaces\Payment\AuthorizationFlow\ConfigurationInterface;
@@ -13,27 +14,8 @@ class _PaymentWithAuthorizationConfig extends PaymentRetrieved
     /**
      * @var AuthorizationFlowInterface
      */
+    #[Field]
     protected AuthorizationFlowInterface $authorizationFlow;
-
-    /**
-     * @return mixed[]
-     */
-    protected function casts(): array
-    {
-        return \array_merge(parent::casts(), [
-            'authorization_flow' => AuthorizationFlowInterface::class,
-        ]);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'authorization_flow',
-        ]);
-    }
 
     /**
      * @return AuthorizationFlowInterface|null
@@ -48,8 +30,6 @@ class _PaymentWithAuthorizationConfig extends PaymentRetrieved
      */
     public function getAuthorizationFlowConfig(): ?ConfigurationInterface
     {
-        return $this->getAuthorizationFlow()
-            ? $this->getAuthorizationFlow()->getConfig()
-            : null;
+        return $this->getAuthorizationFlow()?->getConfig();
     }
 }

--- a/src/Entities/Payment/PaymentRiskAssessment.php
+++ b/src/Entities/Payment/PaymentRiskAssessment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\PaymentRiskAssessmentInterface;
 
@@ -12,14 +13,8 @@ class PaymentRiskAssessment extends Entity implements PaymentRiskAssessmentInter
     /**
      * @var string
      */
+    #[Field]
     protected string $segment;
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'segment',
-    ];
 
     /**
      * @return string|null

--- a/src/Entities/Payment/Refund/RefundCreated.php
+++ b/src/Entities/Payment/Refund/RefundCreated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\Refund;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\RefundCreatedInterface;
 
@@ -12,14 +13,8 @@ final class RefundCreated extends Entity implements RefundCreatedInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $id;
-
-    /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'id',
-    ];
 
     /**
      * @return string

--- a/src/Entities/Payment/Refund/RefundExecuted.php
+++ b/src/Entities/Payment/Refund/RefundExecuted.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\Refund;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Interfaces\Payment\RefundExecutedInterface;
 
 final class RefundExecuted extends RefundRetrieved implements RefundExecutedInterface
@@ -11,27 +12,8 @@ final class RefundExecuted extends RefundRetrieved implements RefundExecutedInte
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $executedAt;
-
-    /**
-     * @return mixed[]
-     */
-    protected function casts(): array
-    {
-        return \array_merge_recursive(parent::casts(), [
-            'executed_at' => \DateTimeInterface::class,
-        ]);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'executed_at',
-        ]);
-    }
 
     /**
      * @return \DateTimeInterface

--- a/src/Entities/Payment/Refund/RefundFailed.php
+++ b/src/Entities/Payment/Refund/RefundFailed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\Refund;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Interfaces\Payment\RefundFailedInterface;
 
 final class RefundFailed extends RefundRetrieved implements RefundFailedInterface
@@ -11,33 +12,14 @@ final class RefundFailed extends RefundRetrieved implements RefundFailedInterfac
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $failedAt;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $failureReason;
-
-    /**
-     * @return mixed[]
-     */
-    protected function casts(): array
-    {
-        return \array_merge_recursive(parent::casts(), [
-            'failed_at' => \DateTimeInterface::class,
-        ]);
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function arrayFields(): array
-    {
-        return \array_merge(parent::arrayFields(), [
-            'failed_at',
-            'failure_reason',
-        ]);
-    }
 
     /**
      * @return \DateTimeInterface

--- a/src/Entities/Payment/Refund/RefundRequest.php
+++ b/src/Entities/Payment/Refund/RefundRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\Refund;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Exceptions\ApiRequestJsonSerializationException;
 use TrueLayer\Exceptions\ApiResponseUnsuccessfulException;
@@ -25,16 +26,19 @@ final class RefundRequest extends Entity implements RefundRequestInterface, HasA
     /**
      * @var string
      */
+    #[Field]
     protected string $paymentId;
 
     /**
      * @var int
      */
+    #[Field]
     protected int $amountInMinor;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $reference;
 
     /**
@@ -43,20 +47,11 @@ final class RefundRequest extends Entity implements RefundRequestInterface, HasA
     protected ?RequestOptionsInterface $requestOptions = null;
 
     /**
-     * @var string[]
-     */
-    protected array $arrayFields = [
-        'payment_id',
-        'amount_in_minor',
-        'reference',
-    ];
-
-    /**
      * @param string|PaymentRetrievedInterface|PaymentCreatedInterface $payment
      *
+     * @return RefundRequestInterface
      * @throws InvalidArgumentException
      *
-     * @return RefundRequestInterface
      */
     public function payment($payment): RefundRequestInterface
     {
@@ -102,12 +97,12 @@ final class RefundRequest extends Entity implements RefundRequestInterface, HasA
     }
 
     /**
-     * @throws ApiResponseUnsuccessfulException
+     * @return RefundCreatedInterface
      * @throws InvalidArgumentException
      * @throws SignerException
      * @throws ApiRequestJsonSerializationException
      *
-     * @return RefundCreatedInterface
+     * @throws ApiResponseUnsuccessfulException
      */
     public function create(): RefundCreatedInterface
     {

--- a/src/Entities/Payment/Refund/RefundRetrieved.php
+++ b/src/Entities/Payment/Refund/RefundRetrieved.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Entities\Payment\Refund;
 
+use TrueLayer\Attributes\Field;
 use TrueLayer\Constants\RefundStatus;
 use TrueLayer\Entities\Entity;
 use TrueLayer\Interfaces\Payment\RefundRetrievedInterface;
@@ -13,51 +14,38 @@ class RefundRetrieved extends Entity implements RefundRetrievedInterface
     /**
      * @var string
      */
+    #[Field]
     protected string $id;
 
     /**
      * @var int
      */
+    #[Field]
     protected int $amountInMinor;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $currency;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $reference;
 
     /**
      * @var string
      */
+    #[Field]
     protected string $status;
 
     /**
      * @var \DateTimeInterface
      */
+    #[Field]
     protected \DateTimeInterface $createdAt;
-
-    /**
-     * @var class-string[]
-     */
-    protected array $casts = [
-        'created_at' => \DateTimeInterface::class,
-    ];
-
-    /**
-     * @return string[]
-     */
-    protected array $arrayFields = [
-        'id',
-        'amount_in_minor',
-        'currency',
-        'reference',
-        'status',
-        'created_at',
-    ];
 
     /**
      * @return string

--- a/src/Services/Util/Str.php
+++ b/src/Services/Util/Str.php
@@ -14,6 +14,13 @@ class Str
     protected static $camelCache = [];
 
     /**
+     * The cache of snake-cased words.
+     *
+     * @var string[]
+     */
+    protected static $snakeCache = [];
+
+    /**
      * The cache of studly-cased words.
      *
      * @var string[]
@@ -47,7 +54,7 @@ class Str
             return $subject;
         }
 
-        $result = \strstr($subject, (string) $search, true);
+        $result = \strstr($subject, (string)$search, true);
 
         return $result === false ? $subject : $result;
     }
@@ -69,9 +76,44 @@ class Str
     }
 
     /**
+     * Convert a string to snake case.
+     *
+     * @param string $value
+     * @param string $delimiter
+     * @return string
+     */
+    public static function snake($value, $delimiter = '_')
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
+        }
+
+        if (!ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', ucwords($value));
+
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
+        }
+
+        return static::$snakeCache[$key][$delimiter] = $value;
+    }
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function lower($value)
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
-     * @param string                  $haystack
+     * @param string $haystack
      * @param string|iterable<string> $needles
      *
      * @return bool
@@ -79,11 +121,11 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         if (!\is_iterable($needles)) {
-            $needles = (array) $needles;
+            $needles = (array)$needles;
         }
 
         foreach ($needles as $needle) {
-            if ((string) $needle !== '' && \str_ends_with($haystack, $needle)) {
+            if ((string)$needle !== '' && \str_ends_with($haystack, $needle)) {
                 return true;
             }
         }

--- a/src/Traits/ArrayableAttributes.php
+++ b/src/Traits/ArrayableAttributes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TrueLayer\Traits;
 
-use TrueLayer\Attributes\Field;
 use TrueLayer\Constants\DateTime;
 use TrueLayer\Interfaces\ArrayableInterface;
 use TrueLayer\Services\Util\Arr;
@@ -42,7 +41,7 @@ trait ArrayableAttributes
      */
     protected function arrayFields(): array
     {
-        return $this->arrayFields;
+        return empty($this->propertyFieldMap) ? $this->arrayFields : $this->propertyFieldMap;
     }
 
     /**
@@ -112,7 +111,7 @@ trait ArrayableAttributes
     {
         $array = [];
 
-        foreach ($this->getArrayFieldsFromAttributes() as $dotNotation => $propertyKey) {
+        foreach ($this->arrayFields() as $dotNotation => $propertyKey) {
             $dotNotation = \is_int($dotNotation) ? $propertyKey : $dotNotation;
             $propertyKey = Str::camel($propertyKey);
             $method = Str::camel('get_' . $propertyKey);
@@ -159,7 +158,7 @@ trait ArrayableAttributes
      *
      * @return mixed
      */
-    private function convertToValueForArray($value)
+    private function convertToValueForArray($value): mixed
     {
         if (\is_array($value)) {
             return \array_map([$this, 'convertToValueForArray'], $value);
@@ -174,24 +173,5 @@ trait ArrayableAttributes
         }
 
         return $value;
-    }
-
-    private function getArrayFieldsFromAttributes()
-    {
-        $reflectionClass = new \ReflectionClass($this);
-
-        $arrayFields = [];
-
-        foreach ($reflectionClass->getProperties() as $property) {
-            $attributes = $property->getAttributes(Field::class);
-
-            if (!empty($attributes)) {
-                $propertyName = $property->getName();
-                $dotNotationFieldName = $attributes[0]->newInstance()->name ?? Str::snake($propertyName);
-                $arrayFields[$dotNotationFieldName] = $propertyName;
-            }
-        }
-
-        return $arrayFields;
     }
 }

--- a/src/Traits/CastsAttributes.php
+++ b/src/Traits/CastsAttributes.php
@@ -22,16 +22,16 @@ trait CastsAttributes
      */
     protected function casts(): array
     {
-        return $this->casts;
+        return empty($this->propertyCastMap) ? $this->casts : $this->propertyCastMap;
     }
 
     /**
-     * @param mixed[]      $data
+     * @param mixed[] $data
      * @param mixed[]|null $casts
      *
+     * @return mixed[]
      * @throws InvalidArgumentException
      *
-     * @return mixed[]
      */
     protected function castData(array $data, ?array $casts = null): array
     {
@@ -75,7 +75,7 @@ trait CastsAttributes
                             $partData = $this->toDateTime($partData);
                         }
                     } elseif ($abstract === \stdClass::class) {
-                        $partData = (object) $partData;
+                        $partData = (object)$partData;
                     } elseif (\is_array($partData) && \is_string($abstract) && (\interface_exists($abstract) || \class_exists($abstract))) {
                         // @phpstan-ignore-next-line
                         $partData = $this->make($abstract, $partData);
@@ -110,11 +110,11 @@ trait CastsAttributes
      * @template T
      *
      * @param class-string<T> $abstract
-     * @param mixed[]|null    $data
-     *
-     * @throws InvalidArgumentException
+     * @param mixed[]|null $data
      *
      * @return T
+     * @throws InvalidArgumentException
+     *
      */
     abstract protected function make(string $abstract, ?array $data = null);
 }

--- a/tests/integration/StartAuthorizationFlowTest.php
+++ b/tests/integration/StartAuthorizationFlowTest.php
@@ -16,7 +16,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->returnUri('https://foo.bar')
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":null,"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":null},"form":{"input_types":[]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":null,"redirect":{"direct_return_uri":null,"return_uri":"https:\/\/foo.bar"},"form":{"input_types":[]}}');
 });
 
 \it('sends direct return uri', function () {
@@ -25,7 +25,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->directReturnUri('https://foo.baz')
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":null,"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":"https:\/\/foo.baz"},"form":{"input_types":[]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":null,"redirect":{"direct_return_uri":"https:\/\/foo.baz","return_uri":"https:\/\/foo.bar"},"form":{"input_types":[]}}');
 });
 
 \it('sends provider selection', function () {
@@ -34,7 +34,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->enableProviderSelection()
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":{},"scheme_selection":null,"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":null},"form":{"input_types":[]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":{},"scheme_selection":null,"redirect":{"direct_return_uri":null,"return_uri":"https:\/\/foo.bar"},"form":{"input_types":[]}}');
 });
 
 \it('sends scheme selection', function () {
@@ -43,7 +43,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->enableSchemeSelection()
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":{},"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":null},"form":{"input_types":[]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":{},"redirect":{"direct_return_uri":null,"return_uri":"https:\/\/foo.bar"},"form":{"input_types":[]}}');
 });
 
 \it('sends user account selection', function () {
@@ -52,7 +52,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->enableUserAccountSelection()
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":{},"provider_selection":null,"scheme_selection":null,"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":null},"form":{"input_types":[]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":{},"provider_selection":null,"scheme_selection":null,"redirect":{"direct_return_uri":null,"return_uri":"https:\/\/foo.bar"},"form":{"input_types":[]}}');
 });
 
 \it('sends form inputs', function () {
@@ -61,7 +61,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->formInputTypes([FormInputTypes::SELECT, FormInputTypes::TEXT, FormInputTypes::TEXT_WITH_IMAGE])
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":null,"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":null},"form":{"input_types":["select","text","text_with_image"]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":null,"scheme_selection":null,"redirect":{"direct_return_uri":null,"return_uri":"https:\/\/foo.bar"},"form":{"input_types":["select","text","text_with_image"]}}');
 });
 
 \it('sends hpp capabilities', function () {
@@ -70,7 +70,7 @@ use TrueLayer\Tests\Integration\Mocks\StartAuthorizationFlowResponse;
         ->useHPPCapabilities()
         ->start();
 
-    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":{},"scheme_selection":{},"redirect":{"return_uri":"https:\/\/foo.bar","direct_return_uri":null},"form":{"input_types":["text","text_with_image","select"]}}');
+    \expect(\getRequestPayload(1, false))->toBe('{"user_account_selection":null,"provider_selection":{},"scheme_selection":{},"redirect":{"direct_return_uri":null,"return_uri":"https:\/\/foo.bar"},"form":{"input_types":["text","text_with_image","select"]}}');
 });
 
 \it('handles authorizing response', function () {


### PR DESCRIPTION
- Add `Field` attribute to map an entity property to the array/json key
  - `#[Field]` maps to the snake cased array key
  - `#[Field('name')` maps to the `name` key
  - `#[Field('my.nested.field')` maps to a nested array: `["my"=>["nested"=>["field" => value]]]`
- Automatically cast values to the correct types based on the property's type
- Add `ArrayShape(Type)` attribute to help cast property array members